### PR TITLE
linting: check all files by default and add `--report-unused-disable-directives`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "bugs": "https://github.com/eslint-community/eslint-plugin-promise/issues",
   "scripts": {
     "format": "prettier --write .",
-    "lint": "eslint .",
+    "lint": "eslint --report-unused-disable-directives .",
     "prepare": "husky install",
     "test": "jest --coverage"
   },
@@ -55,7 +55,7 @@
     ],
     "*.js": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --report-unused-disable-directives --fix"
     ],
     "*.+(json|md)": [
       "prettier --write"


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [x] Other, please explain: Chore.

**What changes did you make? (Give an overview)**

chore: lint all files by default and add `--report-unused-disable-directives` flag

Linting all by default, and later adding an `.eslintignore` if necessary, allows IDEs to avoid showing errors on intentionally ignored files.