### PR TITLE
chore: remove old Travis CI badge and update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,10 +2,12 @@ node_modules
 .idea
 __tests__
 .npmignore
-.travis.yml
 .eslintrc.json
 docs
 coverage
 .github
 CONTRIBUTING.md
 CODE_OF_CONDUCT.md
+.husky
+.editorconfig
+.prettierignore

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Enforce best practices for JavaScript promises.
 
-[![travis-ci](https://travis-ci.org/xjamundx/eslint-plugin-promise.svg)](https://travis-ci.org/xjamundx/eslint-plugin-promise)
+[![CI](https://github.com/xjamundx/eslint-plugin-promise/actions/workflows/CI.yml/badge.svg)](https://github.com/xjamundx/eslint-plugin-promise/actions/workflows/CI.yml)
 [![npm version](https://badge.fury.io/js/eslint-plugin-promise.svg)](https://www.npmjs.com/package/eslint-plugin-promise)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Enforce best practices for JavaScript promises.
 
-[![CI](https://github.com/xjamundx/eslint-plugin-promise/actions/workflows/CI.yml/badge.svg)](https://github.com/xjamundx/eslint-plugin-promise/actions/workflows/CI.yml)
+[![CI](https://github.com/eslint-community/eslint-plugin-promise/actions/workflows/CI.yml/badge.svg)](https://github.com/eslint-community/eslint-plugin-promise/actions/workflows/CI.yml)
 [![npm version](https://badge.fury.io/js/eslint-plugin-promise.svg)](https://www.npmjs.com/package/eslint-plugin-promise)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [x] Other, please explain:

**What changes did you make? (Give an overview)**
Update build badge now that GitHub Actions is used. When removing the old reference to .travis.yml, saw that there were some other dotfiles that weren't ignored right now