### PR TITLE
ci: Add Node 18 for ESlint 8 only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ jobs:
       matrix:
         eslint: [7, 8]
         node: [12.22.0, 12, 14.17.0, 14, 16]
+        include:
+          - eslint: 8
+            node: 18
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [x] Other, please explain:

**What changes did you make? (Give an overview)**
ESlint 7 doesn't offcially support Node 18, but it can be added to the ESLint 8 matrix