### PR TITLE
fix(prefer-await-to-then): member access without call

### DIFF
--- a/__tests__/prefer-await-to-then.js
+++ b/__tests__/prefer-await-to-then.js
@@ -21,6 +21,12 @@ ruleTester.run('prefer-await-to-then', rule, {
     }`,
     'something().then(async () => await somethingElse())',
     'function foo() { hey.somethingElse(x => {}) }',
+    `const isThenable = (obj) => {
+      return obj && typeof obj.then === 'function';
+    };`,
+    `function isThenable(obj) {
+      return obj && typeof obj.then === 'function';
+    }`,
   ],
 
   invalid: [

--- a/rules/prefer-await-to-then.js
+++ b/rules/prefer-await-to-then.js
@@ -35,7 +35,7 @@ module.exports = {
     }
 
     return {
-      MemberExpression(node) {
+      'CallExpression > MemberExpression.callee'(node) {
         if (isTopLevelScoped() || isInsideYieldOrAwait()) {
           return
         }


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR fixes the prefer-await-to-then rule to not report member access without calling.

close #163
