### PR TITLE
chore: also test ESLint v7 on Node v18

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,10 +7,7 @@ jobs:
     strategy:
       matrix:
         eslint: [7, 8]
-        node: [12.22.0, 12, 14.17.0, 14, 16]
-        include:
-          - eslint: 8
-            node: 18
+        node: [12.22.0, 12, 14.17.0, 14, 16, 18]
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs


### PR DESCRIPTION
Follow-up of #360

ESLint v7 supports `>=12`, so that's also v18