### PR TITLE
feat(always-return): add `ignoreLastCallback` option

### DIFF
--- a/__tests__/always-return.js
+++ b/__tests__/always-return.js
@@ -4,7 +4,7 @@ const rule = require('../rules/always-return')
 const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 11,
   },
 })
 
@@ -48,6 +48,59 @@ ruleTester.run('always-return', rule, {
         }
         return x
       })`,
+    {
+      code: 'hey.then(x => { console.log(x) })',
+      options: [{ ignoreLastCallback: true }],
+    },
+    {
+      code: 'if(foo) { hey.then(x => { console.log(x) }) }',
+      options: [{ ignoreLastCallback: true }],
+    },
+    {
+      code: 'void hey.then(x => { console.log(x) })',
+      options: [{ ignoreLastCallback: true }],
+    },
+    {
+      code: `
+      async function foo() {
+        await hey.then(x => { console.log(x) })
+      }`,
+      options: [{ ignoreLastCallback: true }],
+    },
+    {
+      code: `hey?.then(x => { console.log(x) })`,
+      options: [{ ignoreLastCallback: true }],
+    },
+    {
+      code: `foo = (hey.then(x => { console.log(x) }), 42)`,
+      options: [{ ignoreLastCallback: true }],
+    },
+    {
+      code: `(42, hey.then(x => { console.log(x) }))`,
+      options: [{ ignoreLastCallback: true }],
+    },
+    {
+      code: `
+      hey
+        .then(x => { console.log(x) })
+        .catch(e => console.error(e))`,
+      options: [{ ignoreLastCallback: true }],
+    },
+    {
+      code: `
+      hey
+        .then(x => { console.log(x) })
+        .catch(e => console.error(e))
+        .finally(() => console.error('end'))`,
+      options: [{ ignoreLastCallback: true }],
+    },
+    {
+      code: `
+      hey
+        .then(x => { console.log(x) })
+        .finally(() => console.error('end'))`,
+      options: [{ ignoreLastCallback: true }],
+    },
   ],
 
   invalid: [
@@ -128,6 +181,45 @@ ruleTester.run('always-return', rule, {
           return x
         }
       })`,
+      errors: [{ message }],
+    },
+    {
+      code: `
+      hey
+        .then(function(x) { console.log(x) /* missing return here */ })
+        .then(function(y) { console.log(y) /* no error here */ })`,
+      options: [{ ignoreLastCallback: true }],
+      errors: [{ message, line: 3 }],
+    },
+    {
+      code: `const foo = hey.then(function(x) {});`,
+      options: [{ ignoreLastCallback: true }],
+      errors: [{ message }],
+    },
+    {
+      code: `
+      function foo() {
+        return hey.then(function(x) {});
+      }`,
+      options: [{ ignoreLastCallback: true }],
+      errors: [{ message }],
+    },
+    {
+      code: `
+      async function foo() {
+        return await hey.then(x => { console.log(x) })
+      }`,
+      options: [{ ignoreLastCallback: true }],
+      errors: [{ message }],
+    },
+    {
+      code: `const foo = hey?.then(x => { console.log(x) })`,
+      options: [{ ignoreLastCallback: true }],
+      errors: [{ message }],
+    },
+    {
+      code: `const foo = (42, hey.then(x => { console.log(x) }))`,
+      options: [{ ignoreLastCallback: true }],
       errors: [{ message }],
     },
   ],

--- a/docs/rules/always-return.md
+++ b/docs/rules/always-return.md
@@ -49,33 +49,41 @@ last `then()` callback in a promise chain does not warn if it does not have a
 `return`. Default is `false`.
 
 ```js
+// OK
 promise.then((x) => {
   console.log(x)
-}) // OK
+})
+// OK
 void promise.then((x) => {
   console.log(x)
-}) // OK
+})
+// OK
 await promise.then((x) => {
   console.log(x)
-}) // OK
+})
 
 promise
+  // NG
   .then((x) => {
     console.log(x)
-  }) // NG
+  })
+  // OK
   .then((x) => {
     console.log(x)
-  }) // OK
+  })
 
+// NG
 var v = promise.then((x) => {
   console.log(x)
-}) // NG
+})
+// NG
 var v = await promise.then((x) => {
   console.log(x)
-}) // NG
+})
 function foo() {
+  // NG
   return promise.then((x) => {
     console.log(x)
-  }) // NG
+  })
 }
 ```

--- a/docs/rules/always-return.md
+++ b/docs/rules/always-return.md
@@ -10,10 +10,18 @@ as `return Promise.reject()`.
 #### Valid
 
 ```js
-myPromise.then((val) => val * 2));
-myPromise.then(function(val) { return val * 2; });
-myPromise.then(doSomething); // could be either
-myPromise.then((b) => { if (b) { return "yes" } else { return "no" } });
+myPromise.then((val) => val * 2)
+myPromise.then(function (val) {
+  return val * 2
+})
+myPromise.then(doSomething) // could be either
+myPromise.then((b) => {
+  if (b) {
+    return 'yes'
+  } else {
+    return 'no'
+  }
+})
 ```
 
 #### Invalid
@@ -30,4 +38,44 @@ myPromise.then((b) => {
     forgotToReturn()
   }
 })
+```
+
+#### Options
+
+##### `ignoreLastCallback`
+
+You can pass an `{ ignoreLastCallback: true }` as an option to this rule to the
+last `then()` callback in a promise chain does not warn if it does not have a
+`return`. Default is `false`.
+
+```js
+promise.then((x) => {
+  console.log(x)
+}) // OK
+void promise.then((x) => {
+  console.log(x)
+}) // OK
+await promise.then((x) => {
+  console.log(x)
+}) // OK
+
+promise
+  .then((x) => {
+    console.log(x)
+  }) // NG
+  .then((x) => {
+    console.log(x)
+  }) // OK
+
+var v = promise.then((x) => {
+  console.log(x)
+}) // NG
+var v = await promise.then((x) => {
+  console.log(x)
+}) // NG
+function foo() {
+  return promise.then((x) => {
+    console.log(x)
+  }) // NG
+}
 ```


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [x] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR adds `ignoreLastCallback` option to `always-return` rule.

If `ignoreLastCallback: true`, the last `then()` callback in a promise chain does not warn if it does not have a `return`.

close #59
