### PR TITLE
feat(param-names): add `resolvePattern` and `rejectPattern` option

### DIFF
--- a/__tests__/param-names.js
+++ b/__tests__/param-names.js
@@ -8,7 +8,10 @@ const ruleTester = new RuleTester({
   },
 })
 
-const message = 'Promise constructor parameters must be named resolve, reject'
+const messageForResolve =
+  'Promise constructor parameters must be named to match "^_?resolve$"'
+const messageForReject =
+  'Promise constructor parameters must be named to match "^_?reject$"'
 
 ruleTester.run('param-names', rule, {
   valid: [
@@ -22,24 +25,42 @@ ruleTester.run('param-names', rule, {
     'new Promise((resolve, reject) => {})',
     'new Promise(() => {})',
     'new NonPromise()',
+    {
+      code: 'new Promise((yes, no) => {})',
+      options: [{ resolvePattern: '^yes$', rejectPattern: '^no$' }],
+    },
   ],
 
   invalid: [
     {
       code: 'new Promise(function(reject, resolve) {})',
-      errors: [{ message }],
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
     },
     {
       code: 'new Promise(function(resolve, rej) {})',
-      errors: [{ message }],
+      errors: [{ message: messageForReject }],
     },
     {
       code: 'new Promise(yes => {})',
-      errors: [{ message }],
+      errors: [{ message: messageForResolve }],
     },
     {
       code: 'new Promise((yes, no) => {})',
-      errors: [{ message }],
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
+    },
+    {
+      code: 'new Promise(function(resolve, reject) {})',
+      options: [{ resolvePattern: '^yes$', rejectPattern: '^no$' }],
+      errors: [
+        {
+          message:
+            'Promise constructor parameters must be named to match "^yes$"',
+        },
+        {
+          message:
+            'Promise constructor parameters must be named to match "^no$"',
+        },
+      ],
     },
   ],
 })

--- a/docs/rules/param-names.md
+++ b/docs/rules/param-names.md
@@ -24,3 +24,17 @@ Promise constructor uses the
 [RevealingConstructor pattern](https://blog.domenic.me/the-revealing-constructor-pattern/).
 Using the same parameter names as the language specification makes code more
 uniform and easier to understand.
+
+#### Options
+
+##### `resolvePattern`
+
+You can pass a `{ resolvePattern: "^_?resolve$" }` as an option to this rule to
+the first argument name pattern that the rule allows. Default is
+`"^_?resolve$"`.
+
+##### `rejectPattern`
+
+You can pass a `{ rejectPattern: "^_?reject$" }` as an option to this rule to
+the second argument name pattern that the rule allows. Default is
+`"^_?reject$"`.


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [x] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR adds `resolvePattern` and `rejectPattern` option to `param-names` rule.

close #206
