### PR TITLE
feat(catch-or-return,no-new-statics,no-promise-in-callback,valid-params): add support for `Promise.allSettled()` & `Promise.any()`

### DIFF
--- a/__tests__/catch-or-return.js
+++ b/__tests__/catch-or-return.js
@@ -142,6 +142,22 @@ ruleTester.run('catch-or-return', rule, {
       errors: [{ message: catchMessage }],
     },
     {
+      code: 'Promise.all([])',
+      errors: [{ message: catchMessage }],
+    },
+    {
+      code: 'Promise.allSettled([])',
+      errors: [{ message: catchMessage }],
+    },
+    {
+      code: 'Promise.any([])',
+      errors: [{ message: catchMessage }],
+    },
+    {
+      code: 'Promise.race([])',
+      errors: [{ message: catchMessage }],
+    },
+    {
       code: 'frank().then(to).catch(fn).then(foo)',
       errors: [{ message: catchMessage }],
     },

--- a/__tests__/no-new-statics.js
+++ b/__tests__/no-new-statics.js
@@ -32,6 +32,16 @@ ruleTester.run('no-new-statics', rule, {
       errors: [{ message: "Avoid calling 'new' on 'Promise.all()'" }],
     },
     {
+      code: 'new Promise.allSettled()',
+      output: 'Promise.allSettled()',
+      errors: [{ message: "Avoid calling 'new' on 'Promise.allSettled()'" }],
+    },
+    {
+      code: 'new Promise.any()',
+      output: 'Promise.any()',
+      errors: [{ message: "Avoid calling 'new' on 'Promise.any()'" }],
+    },
+    {
       code: 'new Promise.race()',
       output: 'Promise.race()',
       errors: [{ message: "Avoid calling 'new' on 'Promise.race()'" }],

--- a/__tests__/no-promise-in-callback.js
+++ b/__tests__/no-promise-in-callback.js
@@ -78,6 +78,14 @@ ruleTester.run('no-promise-in-callback', rule, {
       errors: [{ message: errorMessage }],
     },
     {
+      code: 'function x(err) { Promise.allSettled() }',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'function x(err) { Promise.any() }',
+      errors: [{ message: errorMessage }],
+    },
+    {
       code: 'let x = (err) => doThingWith(err).then(a)',
       errors: [{ message: errorMessage }],
     },

--- a/__tests__/valid-params.js
+++ b/__tests__/valid-params.js
@@ -33,6 +33,16 @@ ruleTester.run('valid-params', rule, {
     'Promise.all(iterable)',
     'Promise.all([one, two, three])',
 
+    // valid Promise.allSettled()
+    'Promise.allSettled([])',
+    'Promise.allSettled(iterable)',
+    'Promise.allSettled([one, two, three])',
+
+    // valid Promise.any()
+    'Promise.any([])',
+    'Promise.any(iterable)',
+    'Promise.any([one, two, three])',
+
     // valid Promise.then()
     'somePromise().then(success)',
     'somePromise().then(success, failure)',
@@ -127,6 +137,32 @@ ruleTester.run('valid-params', rule, {
       code: 'Promise.all({}, function() {}, 1, 2)',
       errors: [
         { message: 'Promise.all() requires 1 argument, but received 4' },
+      ],
+    },
+    // invalid Promise.allSettled()
+    {
+      code: 'Promise.allSettled(1, 2, 3)',
+      errors: [
+        { message: 'Promise.allSettled() requires 1 argument, but received 3' },
+      ],
+    },
+    {
+      code: 'Promise.allSettled({}, function() {}, 1, 2)',
+      errors: [
+        { message: 'Promise.allSettled() requires 1 argument, but received 4' },
+      ],
+    },
+    // invalid Promise.any()
+    {
+      code: 'Promise.any(1, 2, 3)',
+      errors: [
+        { message: 'Promise.any() requires 1 argument, but received 3' },
+      ],
+    },
+    {
+      code: 'Promise.any({}, function() {}, 1, 2)',
+      errors: [
+        { message: 'Promise.any() requires 1 argument, but received 4' },
       ],
     },
 

--- a/rules/lib/promise-statics.js
+++ b/rules/lib/promise-statics.js
@@ -2,6 +2,8 @@
 
 module.exports = {
   all: true,
+  allSettled: true,
+  any: true,
   race: true,
   reject: true,
   resolve: true,

--- a/rules/valid-params.js
+++ b/rules/valid-params.js
@@ -48,6 +48,8 @@ module.exports = {
             break
           case 'race':
           case 'all':
+          case 'allSettled':
+          case 'any':
           case 'catch':
           case 'finally':
             if (numArgs !== 1) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [x] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR makes the plugin support for `Promise.allSettled()` and `Promise.any()`.

Specifically, the following rules now support new methods:

- catch-or-return
- no-new-statics
- no-promise-in-callback
- valid-params

close #367
