### PR TITLE
chore: fix branch of rule docs link URL to `main`

### DIFF
--- a/rules/lib/get-docs-url.js
+++ b/rules/lib/get-docs-url.js
@@ -11,7 +11,7 @@ const REPO_URL = 'https://github.com/eslint-community/eslint-plugin-promise'
  * @returns {string} URL to the documentation for the given rule
  */
 function getDocsUrl(ruleName) {
-  return `${REPO_URL}/blob/master/docs/rules/${ruleName}.md`
+  return `${REPO_URL}/blob/main/docs/rules/${ruleName}.md`
 }
 
 module.exports = getDocsUrl


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [x] Other, please explain:

**What changes did you make? (Give an overview)**

This PR fixes the rule's meta data to change the branch that the rule's doc URL links from `master` to `main`.

It's fine because it redirects even before the change, but it doesn't redirect after this change.
