### PR TITLE
fix(no-multiple-resolved): false positives when the last expression in a try block is a call to resolve

### DIFF
--- a/__tests__/no-multiple-resolved.js
+++ b/__tests__/no-multiple-resolved.js
@@ -88,6 +88,74 @@ ruleTester.run('no-multiple-resolved', rule, {
         resolve(value)
       })
     })`,
+    `new Promise(async (resolve, reject) => {
+      try {
+        await foo();
+        resolve();
+      } catch (error) {
+        reject(error);
+      }
+    })`,
+    `new Promise(async (resolve, reject) => {
+      try {
+        const r = await foo();
+        resolve(r);
+      } catch (error) {
+        reject(error);
+      }
+    })`,
+    `new Promise(async (resolve, reject) => {
+      try {
+        const r = await foo();
+        resolve(r());
+      } catch (error) {
+        reject(error);
+      }
+    })`,
+    `new Promise(async (resolve, reject) => {
+      try {
+        const r = await foo();
+        resolve(r.foo);
+      } catch (error) {
+        reject(error);
+      }
+    })`,
+    `new Promise(async (resolve, reject) => {
+      try {
+        const r = await foo();
+        resolve(new r());
+      } catch (error) {
+        reject(error);
+      }
+    })`,
+    `new Promise(async (resolve, reject) => {
+      try {
+        const r = await foo();
+        resolve(import(r));
+      } catch (error) {
+        reject(error);
+      }
+    })`,
+    `new Promise((resolve, reject) => {
+      fn(async function * () {
+        try {
+          const r = await foo();
+          resolve(yield r);
+        } catch (error) {
+          reject(error);
+        }
+      })
+    })`,
+    `new Promise(async (resolve, reject) => {
+      let a;
+      try {
+        const r = await foo();
+        resolve();
+        if(r) return;
+      } catch (error) {
+        reject(error);
+      }
+    })`,
   ],
 
   invalid: [
@@ -297,6 +365,101 @@ ruleTester.run('no-multiple-resolved', rule, {
         } finally {
           resolve(value)
         }
+      })`,
+      errors: [
+        {
+          message:
+            'Promise should not be resolved multiple times. Promise is potentially resolved on line 5.',
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: `new Promise(async (resolve, reject) => {
+        try {
+          const r = await foo();
+          resolve();
+          r();
+        } catch (error) {
+          reject(error);
+        }
+      })`,
+      errors: [
+        {
+          message:
+            'Promise should not be resolved multiple times. Promise is potentially resolved on line 4.',
+          line: 7,
+        },
+      ],
+    },
+    {
+      code: `new Promise(async (resolve, reject) => {
+        let a;
+        try {
+          const r = await foo();
+          resolve();
+          a = r.foo;
+        } catch (error) {
+          reject(error);
+        }
+      })`,
+      errors: [
+        {
+          message:
+            'Promise should not be resolved multiple times. Promise is potentially resolved on line 5.',
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: `new Promise(async (resolve, reject) => {
+        let a;
+        try {
+          const r = await foo();
+          resolve();
+          a = new r();
+        } catch (error) {
+          reject(error);
+        }
+      })`,
+      errors: [
+        {
+          message:
+            'Promise should not be resolved multiple times. Promise is potentially resolved on line 5.',
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: `new Promise(async (resolve, reject) => {
+        let a;
+        try {
+          const r = await foo();
+          resolve();
+          import(r);
+        } catch (error) {
+          reject(error);
+        }
+      })`,
+      errors: [
+        {
+          message:
+            'Promise should not be resolved multiple times. Promise is potentially resolved on line 5.',
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: `new Promise((resolve, reject) => {
+        fn(async function * () {
+          try {
+            const r = await foo();
+            resolve();
+            yield r;
+          } catch (error) {
+            reject(error);
+          }
+        })
       })`,
       errors: [
         {


### PR DESCRIPTION

**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR fixes the `promise/no-multiple-resolved` rule to fix a false positive when the last expression in a try block is a call to resolve with.

close #382