### PR TITLE
ci: replace styfle/cancel-workflow-action with native functionality

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,15 +10,17 @@ on:
       - beta
       - alpha
   pull_request:
+  
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   lint:
     name: ⬣ Lint
     runs-on: ubuntu-latest
     steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -60,9 +62,6 @@ jobs:
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
@@ -93,9 +92,6 @@ jobs:
       contains('refs/heads/main,refs/heads/next,refs/heads/beta,refs/heads/alpha',
       github.ref) && github.event_name == 'push'
     steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [X] Other, please explain:

**What changes did you make? (Give an overview)**

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency, this allows a subsequently queued workflow run to interrupt previous runs in PRs. One less third-party action that could potentially cause an issue further down the line.
