### PR TITLE
fix(no-callback-in-promise): false positives when the exception is an argument

### DIFF
--- a/__tests__/no-callback-in-promise.js
+++ b/__tests__/no-callback-in-promise.js
@@ -34,6 +34,18 @@ ruleTester.run('no-callback-in-promise', rule, {
       code: 'a.then(() => next())',
       options: [{ exceptions: ['next'] }],
     },
+    {
+      code: 'a.then(() => next()).catch((err) => next(err))',
+      options: [{ exceptions: ['next'] }],
+    },
+    {
+      code: 'a.then(next)',
+      options: [{ exceptions: ['next'] }],
+    },
+    {
+      code: 'a.then(next).catch(next)',
+      options: [{ exceptions: ['next'] }],
+    },
   ],
 
   invalid: [

--- a/rules/no-callback-in-promise.js
+++ b/rules/no-callback-in-promise.js
@@ -10,6 +10,8 @@ const hasPromiseCallback = require('./lib/has-promise-callback')
 const isInsidePromise = require('./lib/is-inside-promise')
 const isCallback = require('./lib/is-callback')
 
+const CB_BLACKLIST = ['callback', 'cb', 'next', 'done']
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -47,12 +49,7 @@ module.exports = {
           if (hasPromiseCallback(node)) {
             const name =
               node.arguments && node.arguments[0] && node.arguments[0].name
-            if (
-              name === 'callback' ||
-              name === 'cb' ||
-              name === 'next' ||
-              name === 'done'
-            ) {
+            if (!exceptions.includes(name) && CB_BLACKLIST.includes(name)) {
               context.report({
                 node: node.arguments[0],
                 messageId: 'callback',


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [x] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make?**

Fixes false positives when the exception is an argument of the promise call expression.

![image](https://github.com/eslint-community/eslint-plugin-promise/assets/12452003/2c1593e0-e4ec-492c-aea2-9858d04d282d)
