### PR TITLE
chore!: Update node versions to align with eslint v9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,27 +41,23 @@ jobs:
     strategy:
       matrix:
         eslint: [8]
-        node: [12.22.0, 12, 14.17.0, 14, 16.0.0, 16, 18, 20]
+        node: [18.18.0, 20.9.0, 21.1.0, 22]
         os: [ubuntu-latest]
         include:
           # ESLint v9
           - eslint: 9
-            node: 20
+            node: 22
             os: ubuntu-latest
           # On other platforms
           - os: windows-latest
             eslint: 8
-            node: 18
+            node: 22
           - os: macos-latest
             eslint: 8
-            node: 18
-          # On old ESLint versions
-          - eslint: 7
-            node: 18
-            os: ubuntu-latest
+            node: 22
           # On the minimum supported ESLint/Node.js version
           - eslint: 7.0.0
-            node: 12.22.0
+            node: 18.18.0
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^4.9.3"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "engines": {
-    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
   "funding": "https://opencollective.com/eslint"
 }


### PR DESCRIPTION
**What changes did you make?**

This simply updates the CI and package.json to run the tests against the node versions that ESLint v9 supports

BREAKING CHANGE: Requires Node.js: `^18.18.0 || ^20.9.0 || >=21.1.0`