### PR TITLE
fix: remove `name` from eslintrc config; fixes #489

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,6 @@ const pluginPromise = {
 }
 pluginPromise.configs = {
   recommended: {
-    name: 'promise/recommended',
     plugins: ['promise'],
     rules: recommendedRules,
   },


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Bug fix

**What changes did you make? (Give an overview)**

Remove `name` from eslintrc config. It is only ok on the flat config.

Fixes #489.