### PR TITLE
docs: recommend `util.promisify` instead of pify

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,23 +98,23 @@ or start with the recommended rule set:
 ✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                 | Description                                                                            | 💼  | ⚠️  | 🚫  | 🔧  |
-| :------------------------------------------------------------------- | :------------------------------------------------------------------------------------- | :-- | :-- | :-- | :-- |
-| [always-return](docs/rules/always-return.md)                         | Require returning inside each `then()` to create readable and reusable Promise chains. | ✅  |     |     |     |
-| [avoid-new](docs/rules/avoid-new.md)                                 | Disallow creating `new` promises outside of utility libs (use [pify][] instead).       |     |     | ✅  |     |
-| [catch-or-return](docs/rules/catch-or-return.md)                     | Enforce the use of `catch()` on un-returned promises.                                  | ✅  |     |     |     |
-| [no-callback-in-promise](docs/rules/no-callback-in-promise.md)       | Disallow calling `cb()` inside of a `then()` (use [nodeify][] instead).                |     | ✅  |     |     |
-| [no-multiple-resolved](docs/rules/no-multiple-resolved.md)           | Disallow creating new promises with paths that resolve multiple times.                 |     |     |     |     |
-| [no-native](docs/rules/no-native.md)                                 | Require creating a `Promise` constructor before using it in an ES5 environment.        |     |     | ✅  |     |
-| [no-nesting](docs/rules/no-nesting.md)                               | Disallow nested `then()` or `catch()` statements.                                      |     | ✅  |     |     |
-| [no-new-statics](docs/rules/no-new-statics.md)                       | Disallow calling `new` on a Promise static method.                                     | ✅  |     |     | 🔧  |
-| [no-promise-in-callback](docs/rules/no-promise-in-callback.md)       | Disallow using promises inside of callbacks.                                           |     | ✅  |     |     |
-| [no-return-in-finally](docs/rules/no-return-in-finally.md)           | Disallow return statements in `finally()`.                                             |     | ✅  |     |     |
-| [no-return-wrap](docs/rules/no-return-wrap.md)                       | Disallow wrapping values in `Promise.resolve` or `Promise.reject` when not needed.     | ✅  |     |     |     |
-| [param-names](docs/rules/param-names.md)                             | Enforce consistent param names and ordering when creating new promises.                | ✅  |     |     |     |
-| [prefer-await-to-callbacks](docs/rules/prefer-await-to-callbacks.md) | Prefer `async`/`await` to the callback pattern.                                        |     |     |     |     |
-| [prefer-await-to-then](docs/rules/prefer-await-to-then.md)           | Prefer `await` to `then()`/`catch()`/`finally()` for reading Promise values.           |     |     |     |     |
-| [valid-params](docs/rules/valid-params.md)                           | Enforces the proper number of arguments are passed to Promise functions.               |     | ✅  |     |     |
+| Name                                                                 | Description                                                                                | 💼  | ⚠️  | 🚫  | 🔧  |
+| :------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- | :-- | :-- | :-- | :-- |
+| [always-return](docs/rules/always-return.md)                         | Require returning inside each `then()` to create readable and reusable Promise chains.     | ✅  |     |     |     |
+| [avoid-new](docs/rules/avoid-new.md)                                 | Disallow creating `new` promises outside of utility libs (use [util.promisify][] instead). |     |     | ✅  |     |
+| [catch-or-return](docs/rules/catch-or-return.md)                     | Enforce the use of `catch()` on un-returned promises.                                      | ✅  |     |     |     |
+| [no-callback-in-promise](docs/rules/no-callback-in-promise.md)       | Disallow calling `cb()` inside of a `then()` (use [nodeify][] instead).                    |     | ✅  |     |     |
+| [no-multiple-resolved](docs/rules/no-multiple-resolved.md)           | Disallow creating new promises with paths that resolve multiple times.                     |     |     |     |     |
+| [no-native](docs/rules/no-native.md)                                 | Require creating a `Promise` constructor before using it in an ES5 environment.            |     |     | ✅  |     |
+| [no-nesting](docs/rules/no-nesting.md)                               | Disallow nested `then()` or `catch()` statements.                                          |     | ✅  |     |     |
+| [no-new-statics](docs/rules/no-new-statics.md)                       | Disallow calling `new` on a Promise static method.                                         | ✅  |     |     | 🔧  |
+| [no-promise-in-callback](docs/rules/no-promise-in-callback.md)       | Disallow using promises inside of callbacks.                                               |     | ✅  |     |     |
+| [no-return-in-finally](docs/rules/no-return-in-finally.md)           | Disallow return statements in `finally()`.                                                 |     | ✅  |     |     |
+| [no-return-wrap](docs/rules/no-return-wrap.md)                       | Disallow wrapping values in `Promise.resolve` or `Promise.reject` when not needed.         | ✅  |     |     |     |
+| [param-names](docs/rules/param-names.md)                             | Enforce consistent param names and ordering when creating new promises.                    | ✅  |     |     |     |
+| [prefer-await-to-callbacks](docs/rules/prefer-await-to-callbacks.md) | Prefer `async`/`await` to the callback pattern.                                            |     |     |     |     |
+| [prefer-await-to-then](docs/rules/prefer-await-to-then.md)           | Prefer `await` to `then()`/`catch()`/`finally()` for reading Promise values.               |     |     |     |     |
+| [valid-params](docs/rules/valid-params.md)                           | Enforces the proper number of arguments are passed to Promise functions.                   |     | ✅  |     |     |
 
 <!-- end auto-generated rules list -->
 
@@ -130,7 +130,8 @@ or start with the recommended rule set:
 - (c) 2016 Jamund Ferguson <mailto:jamund@gmail.com> - ISC license.
 
 [nodeify]: https://www.npmjs.com/package/nodeify
-[pify]: https://www.npmjs.com/package/pify
+[util.promisify]:
+  https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original
 [@aaditmshah]: https://github.com/aaditmshah
 [@macklinu]: https://github.com/macklinu
 [@xjamundx]: https://github.com/xjamundx

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ or start with the recommended rule set:
 | [always-return](docs/rules/always-return.md)                         | Require returning inside each `then()` to create readable and reusable Promise chains.     | ✅  |     |     |     |
 | [avoid-new](docs/rules/avoid-new.md)                                 | Disallow creating `new` promises outside of utility libs (use [util.promisify][] instead). |     |     | ✅  |     |
 | [catch-or-return](docs/rules/catch-or-return.md)                     | Enforce the use of `catch()` on un-returned promises.                                      | ✅  |     |     |     |
-| [no-callback-in-promise](docs/rules/no-callback-in-promise.md)       | Disallow calling `cb()` inside of a `then()` (use [nodeify][] instead).                    |     | ✅  |     |     |
+| [no-callback-in-promise](docs/rules/no-callback-in-promise.md)       | Disallow calling `cb()` inside of a `then()` (use [util.callbackify][] instead).           |     | ✅  |     |     |
 | [no-multiple-resolved](docs/rules/no-multiple-resolved.md)           | Disallow creating new promises with paths that resolve multiple times.                     |     |     |     |     |
 | [no-native](docs/rules/no-native.md)                                 | Require creating a `Promise` constructor before using it in an ES5 environment.            |     |     | ✅  |     |
 | [no-nesting](docs/rules/no-nesting.md)                               | Disallow nested `then()` or `catch()` statements.                                          |     | ✅  |     |     |
@@ -129,7 +129,8 @@ or start with the recommended rule set:
 - (c) MMXV jden <mailto:jason@denizac.org> - ISC license.
 - (c) 2016 Jamund Ferguson <mailto:jamund@gmail.com> - ISC license.
 
-[nodeify]: https://www.npmjs.com/package/nodeify
+[util.callbackify]:
+  https://nodejs.org/docs/latest/api/util.html#utilcallbackifyoriginal
 [util.promisify]:
   https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original
 [@aaditmshah]: https://github.com/aaditmshah

--- a/docs/rules/avoid-new.md
+++ b/docs/rules/avoid-new.md
@@ -1,8 +1,9 @@
-# Disallow creating `new` promises outside of utility libs (use [pify][] instead) (`promise/avoid-new`)
+# Disallow creating `new` promises outside of utility libs (use [util.promisify][] instead) (`promise/avoid-new`)
 
 🚫 This rule is _disabled_ in the following configs: ✅ `flat/recommended`, ✅
 `recommended`.
 
 <!-- end auto-generated rule header -->
 
-[pify]: https://www.npmjs.com/package/pify
+[util.promisify]:
+  https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original

--- a/docs/rules/no-callback-in-promise.md
+++ b/docs/rules/no-callback-in-promise.md
@@ -1,4 +1,4 @@
-# Disallow calling `cb()` inside of a `then()` (use [nodeify][] instead) (`promise/no-callback-in-promise`)
+# Disallow calling `cb()` inside of a `then()` (use [util.callbackify][] instead) (`promise/no-callback-in-promise`)
 
 ⚠️ This rule _warns_ in the following configs: ✅ `flat/recommended`, ✅
 `recommended`.
@@ -80,4 +80,5 @@ callback code instead of combining the approaches.
 
 String list of callback function names to exempt.
 
-[nodeify]: https://www.npmjs.com/package/nodeify
+[util.callbackify]:
+  https://nodejs.org/docs/latest/api/util.html#utilcallbackifyoriginal

--- a/rules/avoid-new.js
+++ b/rules/avoid-new.js
@@ -12,7 +12,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description:
-        'Disallow creating `new` promises outside of utility libs (use [pify][] instead).',
+        'Disallow creating `new` promises outside of utility libs (use [util.promisify][] instead).',
       url: getDocsUrl('avoid-new'),
     },
     schema: [],

--- a/rules/no-callback-in-promise.js
+++ b/rules/no-callback-in-promise.js
@@ -18,7 +18,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description:
-        'Disallow calling `cb()` inside of a `then()` (use [nodeify][] instead).',
+        'Disallow calling `cb()` inside of a `then()` (use [util.callbackify][] instead).',
       url: getDocsUrl('no-callback-in-promise'),
     },
     messages: {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update

**What changes did you make? (Give an overview)**

Recommended `util.promisify` over `pify`.

Fixes #210.