### PR TITLE
feat(`catch-or-return`, `prefer-await-to-then`): do not report Cypress commands

### DIFF
--- a/__tests__/catch-or-return.js
+++ b/__tests__/catch-or-return.js
@@ -22,6 +22,10 @@ ruleTester.run('catch-or-return', rule, {
     'Promise.resolve(frank)["catch"](jail)',
     'frank.then(to).finally(fn).catch(jail)',
 
+    // Cypress
+    'cy.get(".myClass").then(go)',
+    'cy.get("button").click().then()',
+
     // arrow function use case
     'postJSON("/smajobber/api/reportJob.json")\n\t.then(()=>this.setState())\n\t.catch(()=>this.setState())',
 

--- a/__tests__/prefer-await-to-then.js
+++ b/__tests__/prefer-await-to-then.js
@@ -16,6 +16,11 @@ ruleTester.run('prefer-await-to-then', rule, {
     'async function hi() { await thing().then() }',
     'async function hi() { await thing().catch() }',
     'async function hi() { await thing().finally() }',
+
+    // Cypress
+    'function hi() { cy.get(".myClass").then(go) }',
+    'function hi() { cy.get("button").click().then() }',
+
     'function * hi() { yield thing().then() }',
     'a = async () => (await something())',
     `a = async () => {

--- a/rules/catch-or-return.js
+++ b/rules/catch-or-return.js
@@ -8,6 +8,7 @@
 
 const getDocsUrl = require('./lib/get-docs-url')
 const isPromise = require('./lib/is-promise')
+const isMemberCallWithObjectName = require('./lib/is-member-call-with-object-name')
 
 module.exports = {
   meta: {
@@ -95,6 +96,11 @@ module.exports = {
         expression.callee.property.type === 'Literal' &&
         expression.callee.property.value === 'catch'
       ) {
+        return true
+      }
+
+      // cy.get().then(a, b);
+      if (isMemberCallWithObjectName('cy', expression)) {
         return true
       }
 

--- a/rules/lib/is-member-call-with-object-name
+++ b/rules/lib/is-member-call-with-object-name
@@ -1,0 +1,18 @@
+'use strict'
+
+/**
+ * @param {string} objectName
+ * @param {Node} node
+ * @returns {node is CallExpression}
+ */
+function isMemberCallWithObjectName(objectName, node) {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'MemberExpression' &&
+    ((node.callee.object.type === 'Identifier' &&
+      node.callee.object.name === objectName) ||
+      isMemberCallWithObjectName(objectName, node.callee.object))
+  )
+}
+
+module.exports = isMemberCallWithObjectName

--- a/rules/prefer-await-to-then.js
+++ b/rules/prefer-await-to-then.js
@@ -7,6 +7,7 @@
 
 const { getAncestors, getScope } = require('./lib/eslint-compat')
 const getDocsUrl = require('./lib/get-docs-url')
+const isMemberCallWithObjectName = require('./lib/is-member-call-with-object-name')
 
 module.exports = {
   meta: {
@@ -53,7 +54,11 @@ module.exports = {
 
     return {
       'CallExpression > MemberExpression.callee'(node) {
-        if (isTopLevelScoped(node) || (!strict && isInsideYieldOrAwait(node))) {
+        if (
+          isTopLevelScoped(node) ||
+          (!strict && isInsideYieldOrAwait(node)) ||
+          isMemberCallWithObjectName('cy', node.parent)
+        ) {
           return
         }
 


### PR DESCRIPTION
Fixes #180

**What is the purpose of this pull request?**

- [x] Changes an existing rule

**What changes did you make? (Give an overview)**

Do not report Cypress commands (e.g., `cy.get('sel').then()`) for `catch-or-return` and `prefer-await-to-then`.