### PR TITLE
ci: add pr title format validation

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,18 @@
+name: Compliance
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mtfoley/pr-compliance-action@11b664f0fcf2c4ce954f05ccfcaab6e52b529f86
+        with:
+          body-auto-close: false
+          body-regex: '.*'
+          ignore-team-members: false


### PR DESCRIPTION
**What is the purpose of this pull request?**

To assist #508 / #506 by ensuring that PR-title's are always valid conventional commit format before merging

**What changes did you make? (Give an overview)**

Added a pinned [mtfoley/pr-compliance-action](https://github.com/mtfoley/pr-compliance-action) similar to what I use at eg. neostandard: https://github.com/neostandard/neostandard/blob/main/.github/workflows/compliance.yml