### PR TITLE
feat(`no-promise-in-callback`): add `exemptDeclarations` option

### DIFF
--- a/__tests__/no-promise-in-callback.js
+++ b/__tests__/no-promise-in-callback.js
@@ -38,6 +38,19 @@ ruleTester.run('no-promise-in-callback', rule, {
 
     // weird case, we assume it's not a big deal if you return (even though you may be cheating)
     'a(function(err) { return doThing().then(a) })',
+
+    {
+      code: `
+        function fn(err) {
+          return { promise: Promise.resolve(err) };
+        }
+      `,
+      options: [
+        {
+          exemptDeclarations: true,
+        },
+      ],
+    },
   ],
 
   invalid: [

--- a/docs/rules/no-promise-in-callback.md
+++ b/docs/rules/no-promise-in-callback.md
@@ -30,6 +30,12 @@ promisify(doSomething)()
   .catch(console.error)
 ```
 
+## Options
+
+### `exemptDeclarations`
+
+Whether or not to exempt function declarations. Defaults to `false`.
+
 ## When Not To Use It
 
 If you do not want to be notified when using promises inside of callbacks, you

--- a/rules/lib/is-inside-callback.js
+++ b/rules/lib/is-inside-callback.js
@@ -2,11 +2,15 @@
 
 const isInsidePromise = require('./is-inside-promise')
 
-function isInsideCallback(node) {
+/**
+ * @param {import('eslint').Rule.Node} node
+ * @param {boolean} [exemptDeclarations]
+ */
+function isInsideCallback(node, exemptDeclarations) {
   const isFunction =
     node.type === 'FunctionExpression' ||
     node.type === 'ArrowFunctionExpression' ||
-    node.type === 'FunctionDeclaration' // this may be controversial
+    (!exemptDeclarations && node.type === 'FunctionDeclaration') // this may be controversial
 
   // it's totally fine to use promises inside promises
   if (isInsidePromise(node)) return

--- a/rules/no-promise-in-callback.js
+++ b/rules/no-promise-in-callback.js
@@ -17,12 +17,23 @@ module.exports = {
       description: 'Disallow using promises inside of callbacks.',
       url: getDocsUrl('no-promise-in-callback'),
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          exemptDeclarations: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       avoidPromiseInCallback: 'Avoid using promises inside of callbacks.',
     },
   },
   create(context) {
+    const { exemptDeclarations = false } = context.options[0] || {}
     return {
       CallExpression(node) {
         if (!isPromise(node)) return
@@ -34,7 +45,11 @@ module.exports = {
         // what about if the parent is an ArrowFunctionExpression
         // would that imply an implicit return?
 
-        if (getAncestors(context, node).some(isInsideCallback)) {
+        if (
+          getAncestors(context, node).some((ancestor) => {
+            return isInsideCallback(ancestor, exemptDeclarations)
+          })
+        ) {
           context.report({
             node: node.callee,
             messageId: 'avoidPromiseInCallback',


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Changes an existing rule

**What changes did you make? (Give an overview)**

For `no-promise-in-callback`, add an `exemptDeclarations` option to prevent reporting when the promise is within function declarations.

Fixes #445
