### PR TITLE
feat(`no-callback-in-promise`): add `timeoutsErr` option

### DIFF
--- a/__tests__/no-callback-in-promise.js
+++ b/__tests__/no-callback-in-promise.js
@@ -17,13 +17,13 @@ ruleTester.run('no-callback-in-promise', rule, {
     'function thing(callback) { callback() }',
     'doSomething(function(err) { callback(err) })',
 
-    // TODO: support safe callbacks (see #220)
-    // 'whatever.then((err) => { process.nextTick(() => cb()) })',
-    // 'whatever.then((err) => { setImmediate(() => cb())) })',
-    // 'whatever.then((err) => setImmediate(() => cb()))',
-    // 'whatever.then((err) => process.nextTick(() => cb()))',
-    // 'whatever.then((err) => process.nextTick(cb))',
-    // 'whatever.then((err) => setImmediate(cb))',
+    // Support safe callbacks (#220)
+    'whatever.then((err) => { process.nextTick(() => cb()) })',
+    'whatever.then((err) => { setImmediate(() => cb()) })',
+    'whatever.then((err) => setImmediate(() => cb()))',
+    'whatever.then((err) => process.nextTick(() => cb()))',
+    'whatever.then((err) => process.nextTick(cb))',
+    'whatever.then((err) => setImmediate(cb))',
 
     // arrow functions and other things
     'let thing = (cb) => cb()',
@@ -96,6 +96,95 @@ ruleTester.run('no-callback-in-promise', rule, {
     {
       code: 'a.catch(function(err) { callback(err) })',
       errors: [{ message: errorMessage }],
+    },
+
+    // #167
+    {
+      code: `
+        function wait (callback) {
+          return Promise.resolve()
+            .then(() => {
+              setTimeout(callback);
+            });
+        }
+      `,
+      errors: [{ message: errorMessage }],
+      options: [
+        {
+          timeoutsErr: true,
+        },
+      ],
+    },
+    {
+      code: `
+        function wait (callback) {
+          return Promise.resolve()
+            .then(() => {
+              setTimeout(() => callback());
+            });
+        }
+      `,
+      errors: [{ message: errorMessage }],
+      options: [
+        {
+          timeoutsErr: true,
+        },
+      ],
+    },
+
+    {
+      code: 'whatever.then((err) => { process.nextTick(() => cb()) })',
+      errors: [{ message: errorMessage }],
+      options: [
+        {
+          timeoutsErr: true,
+        },
+      ],
+    },
+    {
+      code: 'whatever.then((err) => { setImmediate(() => cb()) })',
+      errors: [{ message: errorMessage }],
+      options: [
+        {
+          timeoutsErr: true,
+        },
+      ],
+    },
+    {
+      code: 'whatever.then((err) => setImmediate(() => cb()))',
+      errors: [{ message: errorMessage }],
+      options: [
+        {
+          timeoutsErr: true,
+        },
+      ],
+    },
+    {
+      code: 'whatever.then((err) => process.nextTick(() => cb()))',
+      errors: [{ message: errorMessage }],
+      options: [
+        {
+          timeoutsErr: true,
+        },
+      ],
+    },
+    {
+      code: 'whatever.then((err) => process.nextTick(cb))',
+      errors: [{ message: errorMessage }],
+      options: [
+        {
+          timeoutsErr: true,
+        },
+      ],
+    },
+    {
+      code: 'whatever.then((err) => setImmediate(cb))',
+      errors: [{ message: errorMessage }],
+      options: [
+        {
+          timeoutsErr: true,
+        },
+      ],
     },
   ],
 })

--- a/docs/rules/no-callback-in-promise.md
+++ b/docs/rules/no-callback-in-promise.md
@@ -31,7 +31,14 @@ Callback got called with: null data
 Callback got called with: My error null
 ```
 
-**How to fix it?**
+## Options
+
+### `timeoutsErr`
+
+Boolean as to whether callbacks in timeout functions like `setTimeout` will err.
+Defaults to `false`.
+
+## How to fix it?
 
 Ensure that your callback invocations are wrapped by a deferred execution
 function such as:


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Bug fix
- [x] Changes an existing rule

**What changes did you make? (Give an overview)**

- feat(`no-callback-in-promise`): add `timeoutsErr` option; fixes #167
- fix(`no-callback-in-promise`): ensure timeouts do not err (by default); fixes #220
