### PR TITLE
feat(`valid-params`): add `exclude` option

### DIFF
--- a/__tests__/no-new-statics.js
+++ b/__tests__/no-new-statics.js
@@ -53,18 +53,18 @@ ruleTester.run('no-new-statics', rule, {
       errors: [{ message: "Avoid calling 'new' on 'Promise.withResolvers()'" }],
     },
     {
-      code: [
-        'function foo() {',
-        '  var a = getA()',
-        '  return new Promise.resolve(a)',
-        '}',
-      ].join('\n'),
-      output: [
-        'function foo() {',
-        '  var a = getA()',
-        '  return Promise.resolve(a)',
-        '}',
-      ].join('\n'),
+      code: `
+        function foo() {
+          var a = getA()
+          return new Promise.resolve(a)
+        }
+      `,
+      output: `
+        function foo() {
+          var a = getA()
+          return Promise.resolve(a)
+        }
+      `,
       errors: [{ message: "Avoid calling 'new' on 'Promise.resolve()'" }],
     },
   ],

--- a/__tests__/valid-params.js
+++ b/__tests__/valid-params.js
@@ -78,16 +78,16 @@ ruleTester.run('valid-params', rule, {
     },
 
     // integration test
-    [
-      'Promise.all([',
-      '  Promise.resolve(1),',
-      '  Promise.resolve(2),',
-      '  Promise.reject(Error()),',
-      '])',
-      '  .then(console.log)',
-      '  .catch(console.error)',
-      '  .finally(console.log)',
-    ].join('\n'),
+    `
+      Promise.all([
+        Promise.resolve(1),
+        Promise.resolve(2),
+        Promise.reject(Error()),
+      ])
+        .then(console.log)
+        .catch(console.error)
+        .finally(console.log)
+    `,
   ],
   invalid: [
     // invalid Promise.resolve()

--- a/__tests__/valid-params.js
+++ b/__tests__/valid-params.js
@@ -61,6 +61,22 @@ ruleTester.run('valid-params', rule, {
     'promiseReference.finally(callback)',
     'promiseReference.finally(() => {})',
 
+    {
+      code: `
+        somePromise.then(function() {
+          return sth();
+        }).catch(TypeError, function(e) {
+          //
+        }).catch(function(e) {
+        });
+      `,
+      options: [
+        {
+          exclude: ['catch'],
+        },
+      ],
+    },
+
     // integration test
     [
       'Promise.all([',

--- a/docs/rules/always-return.md
+++ b/docs/rules/always-return.md
@@ -78,11 +78,11 @@ promise
   })
 
 // NG
-var v = promise.then((x) => {
+const v = promise.then((x) => {
   console.log(x)
 })
 // NG
-var v = await promise.then((x) => {
+const v = await promise.then((x) => {
   console.log(x)
 })
 function foo() {

--- a/docs/rules/no-native.md
+++ b/docs/rules/no-native.md
@@ -12,12 +12,12 @@ existence of a native promise implementation. Helpful if you want to use
 #### Valid
 
 ```js
-var Promise = require('bluebird')
-var x = Promise.resolve('good')
+const Promise = require('bluebird')
+const x = Promise.resolve('good')
 ```
 
 #### Invalid
 
 ```js
-var x = Promise.resolve('bad')
+const x = Promise.resolve('bad')
 ```

--- a/docs/rules/valid-params.md
+++ b/docs/rules/valid-params.md
@@ -62,6 +62,12 @@ somePromise().finally(() => {
 somePromise().finally(console.log)
 ```
 
+## Options
+
+### `exclude`
+
+Array of method names to exclude from checks. Defaults to an empty array.
+
 ## When Not To Use It
 
 If you do not want to be notified when passing an invalid number of arguments to

--- a/rules/valid-params.js
+++ b/rules/valid-params.js
@@ -11,7 +11,20 @@ module.exports = {
         'Enforces the proper number of arguments are passed to Promise functions.',
       url: getDocsUrl('valid-params'),
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          exclude: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       requireOneOptionalArgument:
         'Promise.{{ name }}() requires 0 or 1 arguments, but received {{ numArgs }}',
@@ -22,6 +35,7 @@ module.exports = {
     },
   },
   create(context) {
+    const { exclude = [] } = context.options[0] || {}
     return {
       CallExpression(node) {
         if (!isPromise(node)) {
@@ -30,6 +44,10 @@ module.exports = {
 
         const name = node.callee.property.name
         const numArgs = node.arguments.length
+
+        if (exclude.includes(name)) {
+          return
+        }
 
         // istanbul ignore next -- `isPromise` filters out others
         switch (name) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Changes an existing rule

**What changes did you make? (Give an overview)**

Adds an `exclude` option to `valid-params`. Allows use of non-standard methods, e.g., Bluebird `catch`.

Also refactors a few instances of array join into ES6 templates

Fixes #127
