### PR TITLE
feat(catch-or-return): add `allowThenStrict` option

### DIFF
--- a/__tests__/catch-or-return.js
+++ b/__tests__/catch-or-return.js
@@ -89,6 +89,37 @@ ruleTester.run('catch-or-return', rule, {
       options: [{ allowThen: true }],
     },
 
+    // allowThenStrict - .then(null, fn)
+    {
+      code: 'frank().then(go).then(null, doIt)',
+      options: [{ allowThenStrict: true }],
+    },
+    {
+      code: 'frank().then(go).then().then().then().then(null, doIt)',
+      options: [{ allowThenStrict: true }],
+    },
+    {
+      code: 'frank().then(go).then().then(null, function() { /* why bother */ })',
+      options: [{ allowThenStrict: true }],
+    },
+    {
+      code: 'frank.then(go).then(to).then(null, jail)',
+      options: [{ allowThenStrict: true }],
+    },
+
+    {
+      code: 'frank().then(a).then(b).then(null, c)',
+      options: [{ allowThenStrict: true }],
+    },
+    {
+      code: 'frank().then(a).then(b).then().then().then(null, doIt)',
+      options: [{ allowThenStrict: true }],
+    },
+    {
+      code: 'frank().then(a).then(b).then(null, function() { /* why bother */ })',
+      options: [{ allowThenStrict: true }],
+    },
+
     // allowFinally - .finally(fn)
     {
       code: 'frank().then(go).catch(doIt).finally(fn)',
@@ -272,6 +303,37 @@ ruleTester.run('catch-or-return', rule, {
     {
       code: 'frank.then(go).then(to).then(pewPew, jail)',
       errors: [{ message: catchMessage }],
+    },
+
+    {
+      code: 'frank().then(a, b)',
+      errors: [{ message: catchMessage }],
+      options: [{ allowThenStrict: true }],
+    },
+    {
+      code: 'frank().then(go).then(zam, doIt)',
+      errors: [{ message: catchMessage }],
+      options: [{ allowThenStrict: true }],
+    },
+    {
+      code: 'frank().then(a).then(b).then(c, d)',
+      errors: [{ message: catchMessage }],
+      options: [{ allowThenStrict: true }],
+    },
+    {
+      code: 'frank().then(go).then().then().then().then(wham, doIt)',
+      errors: [{ message: catchMessage }],
+      options: [{ allowThenStrict: true }],
+    },
+    {
+      code: 'frank().then(go).then().then(function() {}, function() { /* why bother */ })',
+      errors: [{ message: catchMessage }],
+      options: [{ allowThenStrict: true }],
+    },
+    {
+      code: 'frank.then(go).then(to).then(pewPew, jail)',
+      errors: [{ message: catchMessage }],
+      options: [{ allowThenStrict: true }],
     },
   ],
 })

--- a/__tests__/catch-or-return.js
+++ b/__tests__/catch-or-return.js
@@ -53,14 +53,8 @@ ruleTester.run('catch-or-return', rule, {
       options: [{ allowThen: true }],
     },
 
-    // allowThen - .then(null, fn)
-    { code: 'frank().then(a, b)', options: [{ allowThen: true }] },
     {
       code: 'frank().then(a).then(b).then(null, c)',
-      options: [{ allowThen: true }],
-    },
-    {
-      code: 'frank().then(a).then(b).then(c, d)',
       options: [{ allowThen: true }],
     },
     {
@@ -73,8 +67,13 @@ ruleTester.run('catch-or-return', rule, {
     },
 
     // allowThen - .then(fn, fn)
+    { code: 'frank().then(a, b)', options: [{ allowThen: true }] },
     {
       code: 'frank().then(go).then(zam, doIt)',
+      options: [{ allowThen: true }],
+    },
+    {
+      code: 'frank().then(a).then(b).then(c, d)',
       options: [{ allowThen: true }],
     },
     {
@@ -232,6 +231,46 @@ ruleTester.run('catch-or-return', rule, {
     // assume somePromise.ANYTHING() is a new promise
     {
       code: 'frank().catch(go).someOtherMethod()',
+      errors: [{ message: catchMessage }],
+    },
+
+    // .then(null, fn)
+    {
+      code: 'frank().then(a).then(b).then(null, c)',
+      errors: [{ message: catchMessage }],
+    },
+    {
+      code: 'frank().then(a).then(b).then().then().then(null, doIt)',
+      errors: [{ message: catchMessage }],
+    },
+    {
+      code: 'frank().then(a).then(b).then(null, function() { /* why bother */ })',
+      errors: [{ message: catchMessage }],
+    },
+
+    // .then(fn, fn)
+    {
+      code: 'frank().then(a, b)',
+      errors: [{ message: catchMessage }],
+    },
+    {
+      code: 'frank().then(go).then(zam, doIt)',
+      errors: [{ message: catchMessage }],
+    },
+    {
+      code: 'frank().then(a).then(b).then(c, d)',
+      errors: [{ message: catchMessage }],
+    },
+    {
+      code: 'frank().then(go).then().then().then().then(wham, doIt)',
+      errors: [{ message: catchMessage }],
+    },
+    {
+      code: 'frank().then(go).then().then(function() {}, function() { /* why bother */ })',
+      errors: [{ message: catchMessage }],
+    },
+    {
+      code: 'frank.then(go).then(to).then(pewPew, jail)',
       errors: [{ message: catchMessage }],
     },
   ],

--- a/docs/rules/catch-or-return.md
+++ b/docs/rules/catch-or-return.md
@@ -32,9 +32,28 @@ function doSomethingElse() {
 
 ##### `allowThen`
 
-You can pass an `{ allowThen: true }` as an option to this rule to allow for
-`.then(null, fn)` to be used instead of `catch()` at the end of the promise
-chain.
+The second argument to `then()` can also be used to handle a promise rejection,
+but it won't catch any errors from the first argument callback. Because of this,
+this rule reports usage of `then()` with two arguments without `catch()` by
+default.
+
+However, you can use `{ allowThen: true }` to allow using `then()` with two
+arguments instead of `catch()` to handle promise rejections.
+
+Examples of **incorrect** code for the default `{ allowThen: false }` option:
+
+```js
+myPromise.then(doSomething, handleErrors)
+myPromise.then(null, handleErrors)
+```
+
+Examples of **correct** code for the `{ allowThen: true }` option:
+
+```js
+myPromise.then(doSomething, handleErrors)
+myPromise.then(null, handleErrors)
+myPromise.then(doSomething).catch(handleErrors)
+```
 
 ##### `allowFinally`
 

--- a/docs/rules/catch-or-return.md
+++ b/docs/rules/catch-or-return.md
@@ -55,6 +55,34 @@ myPromise.then(null, handleErrors)
 myPromise.then(doSomething).catch(handleErrors)
 ```
 
+##### `allowThenStrict`
+
+`allowThenStrict` is similar to `allowThen` but it only permits `then` when the
+fulfillment handler is `null`. This option ensures that the final rejected
+handler works like a `catch` and can handle any uncaught errors from the final
+`then`.
+
+Examples of **incorrect** code for the default `{ allowThenStrict: false }`
+option:
+
+```js
+myPromise.then(doSomething, handleErrors)
+myPromise.then(null, handleErrors)
+```
+
+Examples of **correct** code for the `{ allowThenStrict: true }` option:
+
+```js
+myPromise.then(null, handleErrors)
+myPromise.then(doSomething).catch(handleErrors)
+```
+
+Examples of **incorrect** code for the `{ allowThenStrict: true }` option:
+
+```js
+myPromise.then(doSomething, handleErrors)
+```
+
 ##### `allowFinally`
 
 You can pass an `{ allowFinally: true }` as an option to this rule to allow for


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Changes an existing rule

**What changes did you make? (Give an overview)**

Added an `allowThenStrict` option which will fail on `then(fn1, fn2)` but pass on `then(null, fn)`

Also cleaned up the `allowThen` docs and tests.

Closes #52