### PR TITLE
ci: follow up fixes to `release-please`

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   format:
     if: github.repository == 'eslint-community/eslint-plugin-promise'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 .github/release-please/manifest.json
 coverage
+CHANGELOG.md


### PR DESCRIPTION
Ignores the `CHANGELOG.md` in prettier, to allow for the `release-please` formatting to be accepted

And fixes the formatting workflow, have it request correct permissions
