### PR TITLE
chore(package): explicitly declare js module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "eslint-plugin-promise",
   "version": "7.2.1",
   "description": "Enforce best practices for JavaScript promises",
+  "main": "index.js",
+  "type": "commonjs",
   "keywords": [
     "eslint",
     "eslintplugin",


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [x] Other, please explain:

[Node 21.1.0 added a flag to detect module types](https://github.com/nodejs/node/releases/tag/v21.1.0), that became enabled by [default in Node 22.7.0](https://nodejs.org/api/packages.html#syntax-detection).
Declaring the type will cause Node to skip detection on startup, reducing startup time.

Declaring the package type is also considered good practice according to https://nodejs.org/api/modules.html#enabling.

**What changes did you make? (Give an overview)**

Updated `package.json` with `main` and `type` keys and values.

