### PR TITLE
ci(release-please/config): use main schema link

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/v16.12.0/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
   "changelog-sections": [


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [x] Other, please explain:

Updates the release-please schema to use the main schema rather than a pinned version which is 8 months out of date. As long as the action is kept up to date (which renovate will do) then using main should not be an issue.

**What changes did you make? (Give an overview)**

Changed release-please schema link.