### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/rules/prefer-await-to-then.js
+++ b/rules/prefer-await-to-then.js
@@ -25,6 +25,7 @@ module.exports = {
             type: 'boolean',
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

`prefer-await-to-then` rule currently allows extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in this rule's options schema.
