### PR TITLE
fix(no-native): fix to report `Promise` usage in eslint v9 or later

### DIFF
--- a/__tests__/no-native.js
+++ b/__tests__/no-native.js
@@ -53,6 +53,11 @@ for (const ruleTester of ruleTesters) {
         errors: [{ message: '"Promise" is not defined.' }],
         globals: { Promise: true },
       },
+      {
+        code: 'Promise.resolve()',
+        errors: [{ message: '"Promise" is not defined.' }],
+        globals: { Promise: 'off' },
+      },
     ],
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3617,6 +3617,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",

--- a/rules/no-native.js
+++ b/rules/no-native.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const { getScope } = require('./lib/eslint-compat')
+const { getSourceCode } = require('./lib/eslint-compat')
 const getDocsUrl = require('./lib/get-docs-url')
 
 function isDeclared(scope, ref) {
@@ -46,22 +46,24 @@ module.exports = {
      * @private
      */
     return {
-      'Program:exit'(node) {
-        const scope = getScope(context, node)
-        const leftToBeResolved =
-          scope.implicit.left ||
-          /**
-           * Fixes https://github.com/eslint-community/eslint-plugin-promise/issues/205.
-           * The problem was that @typescript-eslint has a scope manager
-           * which has `leftToBeResolved` instead of the default `left`.
-           */
-          scope.implicit.leftToBeResolved
+      'Program:exit'() {
+        const sourceCode = getSourceCode(context)
+        /** @type {import('eslint').Scope.Scope} */
+        const scope = sourceCode.scopeManager.globalScope
 
-        leftToBeResolved.forEach((ref) => {
-          if (ref.identifier.name !== 'Promise') {
-            return
+        for (const variable of scope.variables) {
+          if (variable.name !== 'Promise') {
+            continue
           }
-
+          variable.references.forEach(validatePromiseReference)
+        }
+        for (const ref of scope.through) {
+          if (ref.identifier.name !== 'Promise') {
+            continue
+          }
+          validatePromiseReference(ref)
+        }
+        function validatePromiseReference(ref) {
           // istanbul ignore else
           if (!isDeclared(scope, ref)) {
             context.report({
@@ -70,7 +72,7 @@ module.exports = {
               data: { name: ref.identifier.name },
             })
           }
-        })
+        }
       },
     }
   },


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [x] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

In this PR, I changed the no-native rule to be tolerant of reporting global promises and undefined promises.
This change allows for compatibility with ESLint v9 and v10.

closes #611
