### PR TITLE
docs: merge duplicate Options sections in no-callback-in-promise

### DIFF
--- a/docs/rules/no-callback-in-promise.md
+++ b/docs/rules/no-callback-in-promise.md
@@ -33,6 +33,10 @@ Callback got called with: My error null
 
 ## Options
 
+### `exceptions`
+
+String list of callback function names to exempt.
+
 ### `timeoutsErr`
 
 Boolean as to whether callbacks in timeout functions like `setTimeout` will err.
@@ -80,12 +84,5 @@ callback code instead of combining the approaches.
   https://nodejs.org/docs/latest/api/process.html#process_process_nexttick_callback_args
 [settimeout()]:
   https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout
-
-## Options
-
-### `exceptions`
-
-String list of callback function names to exempt.
-
 [util.callbackify]:
   https://nodejs.org/docs/latest/api/util.html#utilcallbackifyoriginal


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

Fixed a duplicate `## Options` heading in the `no-callback-in-promise` rule docs.
