### PR TITLE
feat: add TypeScript type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,36 @@
+import type { ESLint, Linter, Rule } from 'eslint'
+
+declare const eslintPluginPromise: ESLint.Plugin & {
+  rules: {
+    'always-return': Rule.RuleModule
+    'avoid-new': Rule.RuleModule
+    'catch-or-return': Rule.RuleModule
+    'no-callback-in-promise': Rule.RuleModule
+    'no-multiple-resolved': Rule.RuleModule
+    'no-native': Rule.RuleModule
+    'no-nesting': Rule.RuleModule
+    'no-new-statics': Rule.RuleModule
+    'no-promise-in-callback': Rule.RuleModule
+    'no-return-in-finally': Rule.RuleModule
+    'no-return-wrap': Rule.RuleModule
+    'param-names': Rule.RuleModule
+    'prefer-await-to-callbacks': Rule.RuleModule
+    'prefer-await-to-then': Rule.RuleModule
+    'prefer-catch': Rule.RuleModule
+    'spec-only': Rule.RuleModule
+    'valid-params': Rule.RuleModule
+  }
+  rulesConfig: {
+    'always-return': Linter.Severity
+    'catch-or-return': Linter.Severity
+    'no-native': Linter.Severity
+    'no-return-wrap': Linter.Severity
+    'param-names': Linter.Severity
+  }
+  configs: {
+    recommended: Linter.LegacyConfig
+    'flat/recommended': Linter.Config
+  }
+}
+
+export = eslintPluginPromise

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.3.0",
   "description": "Enforce best practices for JavaScript promises",
   "main": "index.js",
+  "types": "index.d.ts",
   "type": "commonjs",
   "keywords": [
     "eslint",


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [x] Other, please explain: ship TypeScript types with the plugin

Closes #488.

A small stopgap so the plugin imports cleanly in TypeScript today. Not meant to preempt the broader TS migration discussed in #488.

**What changes did you make? (Give an overview)**

- Adds a hand-written `index.d.ts` at the package root.
- Adds `"types": "index.d.ts"` to `package.json` so consumers pick it up.

The declarations cover the published surface (`rules`, `rulesConfig`, `configs.recommended` as `Linter.LegacyConfig`, `configs['flat/recommended']` as `Linter.Config`) and are adapted from @JoshuaKGoldberg's [DefinitelyTyped/DefinitelyTyped#75007](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75007), reformatted to match this repo's Prettier config.

**Drift risk**

The d.ts is hand-maintained, so new rules must be added in both places; happy to follow up with an automated check