### PR TITLE
fix(always-return): skip unreachable final segments

### DIFF
--- a/__tests__/always-return.js
+++ b/__tests__/always-return.js
@@ -15,6 +15,7 @@ ruleTester.run('always-return', rule, {
     'hey.then(x => x)',
     'hey.then(x => ({}))',
     'hey.then(x => { return; })',
+    'hey.then(() => { try { return 1; } finally { return 2; } })',
     'hey.then(x => { return x ? x.id : null })',
     'hey.then(x => { return x * 10 })',
     'hey.then(x => { process.exit(0); })',

--- a/rules/always-return.js
+++ b/rules/always-return.js
@@ -299,6 +299,9 @@ module.exports = {
         }
 
         path.finalSegments.forEach((segment) => {
+          if (!segment.reachable) {
+            return
+          }
           const id = segment.id
           const branch = funcInfo.branchInfoMap[id]
           if (!branch.good) {


### PR DESCRIPTION
`promise/always-return` could crash on callbacks where both the `try` and `finally` branches return, because it tried to read branch information from an unreachable final code-path segment.
This skips unreachable segments before checking their return state. I added regression coverage and ran the focused rule tests with 74 passing, the full suite with 565 passing and 100% coverage, lint, and `git diff --check`.
Fixes #630
