### PR TITLE
fix(prefer-catch): avoid unsafe autofix for two-argument then

### DIFF
--- a/__tests__/prefer-catch.js
+++ b/__tests__/prefer-catch.js
@@ -26,12 +26,12 @@ ruleTester.run('prefer-catch', rule, {
     {
       code: 'hey.then(fn1, fn2)',
       errors: [{ message }],
-      output: 'hey.catch(fn2).then(fn1)',
+      output: null,
     },
     {
       code: 'hey.then(fn1, (fn2))',
       errors: [{ message }],
-      output: 'hey.catch(fn2).then(fn1)',
+      output: null,
     },
     {
       code: 'hey.then(null, fn2)',
@@ -46,7 +46,7 @@ ruleTester.run('prefer-catch', rule, {
     {
       code: 'function foo() { hey.then(x => {}, () => {}) }',
       errors: [{ message }],
-      output: 'function foo() { hey.catch(() => {}).then(x => {}) }',
+      output: null,
     },
     {
       code: `
@@ -55,11 +55,7 @@ ruleTester.run('prefer-catch', rule, {
         }
       `,
       errors: [{ message }, { message }],
-      output: `
-        function foo() {
-          hey.catch(function b() {}).then(function a() { }).catch(fn2).then(fn1)
-        }
-      `,
+      output: null,
     },
   ],
 })

--- a/rules/prefer-catch.js
+++ b/rules/prefer-catch.js
@@ -42,14 +42,6 @@ module.exports = {
               ) {
                 yield removeArgument(fixer, then, sourceCode)
                 yield fixer.replaceText(node.property, 'catch')
-              } else {
-                const catcher = node.parent.arguments[1]
-                const catcherText = sourceCode.getText(catcher)
-                yield removeArgument(fixer, catcher, sourceCode)
-                yield fixer.insertTextBefore(
-                  node.property,
-                  `catch(${catcherText}).`,
-                )
               }
             },
           })


### PR DESCRIPTION
## Summary
- stop autofixing `then(onFulfilled, onRejected)` into a reordered `.catch().then()` chain
- keep the safe autofix for `then(null, onRejected)` and `then(undefined, onRejected)`
- update `prefer-catch` fixer tests to assert no fix is emitted when preserving semantics is not possible

Fixes #613

## Verification
- `jest __tests__/prefer-catch.js --runInBand`
- `jest --runInBand`
- `eslint --report-unused-disable-directives rules/prefer-catch.js __tests__/prefer-catch.js`
- `git diff --check`