### PR TITLE
fix: ignore super catch calls in promise rules

### DIFF
--- a/__tests__/prefer-await-to-then.js
+++ b/__tests__/prefer-await-to-then.js
@@ -39,6 +39,11 @@ ruleTester.run('prefer-await-to-then', rule, {
         doSomething.then(abc);
       }
     }`,
+    `class Child extends Mother {
+      catch(exception, host) {
+        super.catch(exception, host)
+      }
+    }`,
   ],
 
   invalid: [

--- a/__tests__/valid-params.js
+++ b/__tests__/valid-params.js
@@ -54,6 +54,11 @@ ruleTester.run('valid-params', rule, {
     'somePromise().catch(err => {})',
     'promiseReference.catch(callback)',
     'promiseReference.catch(err => {})',
+    `class Child extends Mother {
+      catch(exception, host) {
+        super.catch(exception, host)
+      }
+    }`,
 
     // valid Promise.finally()
     'somePromise().finally(callback)',

--- a/rules/lib/is-promise.js
+++ b/rules/lib/is-promise.js
@@ -7,6 +7,14 @@
 const PROMISE_STATICS = require('./promise-statics')
 
 function isPromise(expression) {
+  if (
+    expression.type === 'CallExpression' &&
+    expression.callee.type === 'MemberExpression' &&
+    expression.callee.object.type === 'Super'
+  ) {
+    return false
+  }
+
   return (
     // hello.then()
     (expression.type === 'CallExpression' &&

--- a/rules/prefer-await-to-then.js
+++ b/rules/prefer-await-to-then.js
@@ -67,7 +67,8 @@ module.exports = {
           isTopLevelScoped(node) ||
           (!strict && isInsideYieldOrAwait(node)) ||
           (!strict && isInsideConstructor(node)) ||
-          isMemberCallWithObjectName('cy', node.parent)
+          isMemberCallWithObjectName('cy', node.parent) ||
+          node.object.type === 'Super'
         ) {
           return
         }


### PR DESCRIPTION
## Summary
- ignore `super.then`/`super.catch`/`super.finally` calls in the shared promise-call detector
- skip `super` member calls in `prefer-await-to-then`
- add regression coverage for a Nest-like `super.catch(exception, host)` call

Fixes #599

## Verification
- `jest __tests__/valid-params.js __tests__/prefer-await-to-then.js --runInBand`
- `jest --runInBand`
- `eslint --report-unused-disable-directives rules/lib/is-promise.js rules/prefer-await-to-then.js __tests__/valid-params.js __tests__/prefer-await-to-then.js`
- `git diff --check`